### PR TITLE
feat: Improve redis game store and packages upload

### DIFF
--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -768,6 +768,35 @@
             }
           }
         }
+      },
+      "delete": {
+        "summary": "Delete game",
+        "tags": ["Games"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User deleted successfully"
+          },
+          "400": {
+            "description": "Game not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GameNotFoundResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/subscription/games": {

--- a/server/src/controllers/rest/AuthRestApiController.ts
+++ b/server/src/controllers/rest/AuthRestApiController.ts
@@ -19,9 +19,6 @@ import { ClientError } from "error/ClientError";
 import { Logger } from "utils/Logger";
 import { UserRepository } from "database/repositories/UserRepository";
 import { IDiscordProfile } from "types/discord/discord";
-import { EFileSource } from "enums/file/EFileSource";
-import { getDiscordCDNLink } from "constants/discord";
-import { FileRepository } from "database/repositories/FileRepository";
 import { IRegisterUser } from "types/user/IRegisterUser";
 
 export class AuthRestApiController {
@@ -134,7 +131,6 @@ export class AuthRestApiController {
         id: Joi.string().required(),
         username: Joi.string().required(),
         email: Joi.string().email().allow(null),
-        avatar: Joi.string().allow(null),
       })
     ).validate();
 
@@ -146,15 +142,6 @@ export class AuthRestApiController {
       user = new User();
       user.discord_id = profile.id;
       user.username = profile.username;
-      if (profile.avatar) {
-        const fileRepo = FileRepository.getRepository(this.ctx.db);
-        const file = await fileRepo.writeFile(
-          getDiscordCDNLink(profile.id, profile.avatar),
-          profile.avatar,
-          EFileSource.DISCORD
-        );
-        user.avatar = file;
-      }
       user.email = profile.email ?? null;
 
       const registerData: IRegisterUser = await user.export();

--- a/server/src/database/managers/game/GameIndexManager.ts
+++ b/server/src/database/managers/game/GameIndexManager.ts
@@ -1,0 +1,219 @@
+import Redis, { ChainableCommander } from "ioredis";
+
+import { GAME_NAMESPACE } from "constants/game";
+import { IGame } from "types/game/IGame";
+import { EPaginationOrder } from "types/pagination/IPaginationOpts";
+import { ValueUtils } from "utils/ValueUtils";
+
+export class GameIndexManager {
+  private readonly INDEX_PREFIX = `${GAME_NAMESPACE}:index`;
+  private readonly TEMP_KEY_TTL = 30; // seconds
+
+  constructor(private readonly redis: Redis) {
+    //
+  }
+
+  public addGameToIndexesPipeline(
+    pipeline: ChainableCommander,
+    gameId: string,
+    gameData: IGame
+  ): ChainableCommander {
+    // Add all index operations to the same pipeline
+    pipeline.zadd(
+      this._createdAtIndexKey,
+      gameData.createdAt.getTime(),
+      gameId
+    );
+
+    if (gameData.isPrivate) {
+      pipeline.sadd(this._privacyIndexKey(true), gameId);
+    }
+
+    pipeline.zadd(
+      this._titleIndexKey,
+      0,
+      `${gameData.title.toLowerCase()}:${gameId}`
+    );
+
+    return pipeline;
+  }
+
+  public async addGameToIndexes(gameId: string, gameData: IGame) {
+    return Promise.all([
+      this._addToCreatedAtIndex(gameId, gameData),
+      this._addToPrivacyIndex(gameId, gameData),
+      this._addToTitleIndex(gameId, gameData),
+    ]);
+  }
+
+  public async removeGameFromIndexes(gameId: string, gameData: IGame) {
+    return Promise.all([
+      this.redis.zrem(this._createdAtIndexKey, gameId),
+      this.redis.srem(this._privacyIndexKey(gameData.isPrivate), gameId),
+      this.redis.zrem(
+        this._titleIndexKey,
+        `${gameData.title.toLowerCase()}:${gameId}`
+      ),
+    ]);
+  }
+
+  public async findGamesByIndex(
+    filters: {
+      createdAt?: { min?: Date; max?: Date };
+      isPrivate?: boolean;
+      titlePrefix?: string;
+    },
+    pagination: { offset: number; limit: number; order: EPaginationOrder }
+  ): Promise<{ ids: string[]; total: number }> {
+    const tempKey = `${this.INDEX_PREFIX}:temp:${Date.now()}`;
+
+    try {
+      await this._buildCompositeIndex(tempKey, filters);
+      return this._paginateResults(tempKey, pagination);
+    } finally {
+      await this.redis.expire(tempKey, this.TEMP_KEY_TTL);
+    }
+  }
+
+  private async _buildCompositeIndex(
+    tempKey: string,
+    filters: {
+      createdAt?: { min?: Date; max?: Date };
+      isPrivate?: boolean;
+      titlePrefix?: string;
+    }
+  ) {
+    const filterSteps: Promise<unknown>[] = [];
+    const indexKeys: string[] = [this._createdAtIndexKey];
+
+    // Privacy Filter
+    if (ValueUtils.isBoolean(filters.isPrivate)) {
+      indexKeys.push(this._privacyIndexKey(filters.isPrivate));
+      filterSteps.push(Promise.resolve()); // No value needed for sets
+    }
+
+    // Title Filter
+    if (filters.titlePrefix) {
+      const titleKey = await this._prepareTitleFilter(
+        filters.titlePrefix,
+        tempKey
+      );
+      if (titleKey) indexKeys.push(titleKey);
+    }
+
+    // Date Range Filter
+    if (filters.createdAt) {
+      // Copy the main createdAt index into a temporary key.
+      const createdAtIndexKeyToUse = `${tempKey}:createdAt`;
+      await this.redis.zunionstore(
+        createdAtIndexKeyToUse,
+        1,
+        this._createdAtIndexKey
+      );
+
+      // Determine the score boundaries based on the provided dates.
+      const minScore = filters.createdAt.min
+        ? filters.createdAt.min.getTime()
+        : "-inf";
+      const maxScore = filters.createdAt.max
+        ? filters.createdAt.max.getTime()
+        : "+inf";
+
+      // Remove elements outside the desired range from the temporary index.
+      await this.redis.zremrangebyscore(
+        createdAtIndexKeyToUse,
+        "-inf",
+        minScore
+      );
+      await this.redis.zremrangebyscore(
+        createdAtIndexKeyToUse,
+        maxScore,
+        "+inf"
+      );
+    }
+
+    // Combine indexes
+    await this.redis.zinterstore(
+      tempKey,
+      indexKeys.length,
+      ...indexKeys,
+      "WEIGHTS",
+      ...indexKeys.map((_, i) => (i === 0 ? 1 : 0))
+    );
+  }
+
+  private async _prepareTitleFilter(prefix: string, tempKey: string) {
+    const normalizedPrefix = prefix.toLowerCase();
+    const titleMatches = await this.redis.zrangebylex(
+      this._titleIndexKey,
+      `[${normalizedPrefix}`,
+      `[${normalizedPrefix}\xff`
+    );
+
+    if (titleMatches.length > 0) {
+      const titleFilterKey = `${tempKey}:title`;
+      await this.redis.sadd(
+        titleFilterKey,
+        ...titleMatches.map((m) => m.split(":")[1])
+      );
+      return titleFilterKey;
+    }
+    return null;
+  }
+
+  private async _paginateResults(
+    tempKey: string,
+    pagination: { offset: number; limit: number; order: EPaginationOrder }
+  ) {
+    const [total, ids] = await Promise.all([
+      this.redis.zcard(tempKey),
+      pagination.order === EPaginationOrder.DESC
+        ? this.redis.zrevrange(
+            tempKey,
+            pagination.offset,
+            pagination.offset + pagination.limit - 1
+          )
+        : this.redis.zrange(
+            tempKey,
+            pagination.offset,
+            pagination.offset + pagination.limit - 1
+          ),
+    ]);
+
+    return { ids, total };
+  }
+
+  private async _addToCreatedAtIndex(gameId: string, gameData: IGame) {
+    return this.redis.zadd(
+      this._createdAtIndexKey,
+      gameData.createdAt.getTime(),
+      gameId
+    );
+  }
+
+  private async _addToPrivacyIndex(gameId: string, gameData: IGame) {
+    if (gameData.isPrivate) {
+      await this.redis.sadd(this._privacyIndexKey(true), gameId);
+    }
+  }
+
+  private async _addToTitleIndex(gameId: string, gameData: IGame) {
+    await this.redis.zadd(
+      this._titleIndexKey,
+      0,
+      `${gameData.title.toLowerCase()}:${gameId}`
+    );
+  }
+
+  private get _createdAtIndexKey() {
+    return `${this.INDEX_PREFIX}:createdAt`;
+  }
+
+  private _privacyIndexKey(isPrivate: boolean) {
+    return `${this.INDEX_PREFIX}:isPrivate:${isPrivate}`;
+  }
+
+  private get _titleIndexKey() {
+    return `${this.INDEX_PREFIX}:title`;
+  }
+}

--- a/server/src/database/repositories/FileRepository.ts
+++ b/server/src/database/repositories/FileRepository.ts
@@ -2,6 +2,7 @@ import { type Repository } from "typeorm";
 import { type Database } from "database/Database";
 import { File } from "database/models/File";
 import { EFileSource } from "enums/file/EFileSource";
+import { IFile } from "types/file/IFile";
 
 export class FileRepository {
   private static _instance: FileRepository;
@@ -17,6 +18,10 @@ export class FileRepository {
     }
 
     return this._instance;
+  }
+
+  public async bulkWriteFiles(files: IFile[]) {
+    return this._repository.insert(files);
   }
 
   public async writeFile(path: string, filename: string, source: EFileSource) {

--- a/server/src/database/repositories/FileUsageRepository.ts
+++ b/server/src/database/repositories/FileUsageRepository.ts
@@ -39,6 +39,24 @@ export class FileUsageRepository {
     return this._repository.save(usage);
   }
 
+  public async writeBulkUsage(filesData: {
+    files: File[];
+    user?: User;
+    pack?: Package;
+  }) {
+    const fileUsages = filesData.files.map((f) => {
+      const usage = new FileUsage();
+      usage.import({
+        file: f,
+        package: filesData.pack,
+        user: filesData.user,
+      });
+      return usage;
+    });
+
+    return this._repository.insert(fileUsages);
+  }
+
   public async deleteUsage(file: File, user?: User, pack?: Package) {
     const opts: { [key: string]: any } = { file: { id: file.id } };
 

--- a/server/src/database/repositories/PackageRepository.ts
+++ b/server/src/database/repositories/PackageRepository.ts
@@ -1,4 +1,4 @@
-import { Repository } from "typeorm";
+import { In, Repository } from "typeorm";
 import { Package } from "database/models/Package";
 import { Database } from "database/Database";
 import { OQContentStructure } from "types/file/structures/OQContentStructure";
@@ -101,6 +101,16 @@ export class PackageRepository {
       qb,
       paginationOpts
     );
+  }
+
+  public findByIds(
+    ids: number[],
+    selectOptions?: ISelectOptions<Package>
+  ): Promise<Package[]> {
+    return this._repository.find({
+      where: { id: In(ids) },
+      relations: selectOptions?.relations ?? ["author"],
+    });
   }
 
   public async create(content: OQContentStructure, author: User) {

--- a/server/src/database/repositories/UserRepository.ts
+++ b/server/src/database/repositories/UserRepository.ts
@@ -1,5 +1,4 @@
-import { SessionData } from "express-session";
-import { FindOptionsWhere, type Repository } from "typeorm";
+import { FindOptionsWhere, In, type Repository } from "typeorm";
 
 import { User } from "database/models/User";
 import { type Database } from "database/Database";
@@ -13,6 +12,7 @@ import { HttpStatus } from "enums/HttpStatus";
 import { PaginatedResults } from "database/pagination/PaginatedResults";
 import { IPaginationOpts } from "types/pagination/IPaginationOpts";
 import { IRegisterUser } from "types/user/IRegisterUser";
+import { Session } from "types/auth/session";
 
 const USER_SELECT_FIELDS: (keyof User)[] = [
   "id",
@@ -71,6 +71,16 @@ export class UserRepository {
       where,
       select: selectOptions?.select ?? USER_SELECT_FIELDS,
       relations: selectOptions?.relations ?? ["avatar"],
+    });
+  }
+
+  public findByIds(
+    ids: number[],
+    selectOptions?: ISelectOptions<User>
+  ): Promise<User[]> {
+    return this._repository.find({
+      where: { id: In(ids) },
+      select: selectOptions?.relations ?? USER_SELECT_FIELDS,
     });
   }
 
@@ -167,7 +177,7 @@ export class UserRepository {
 
   public static async getUserBySession(
     db: Database,
-    session: SessionData,
+    session: Session,
     options?: ISelectOptions<User>
   ) {
     if (!session.userId) {

--- a/server/src/middleware/authMiddleware.ts
+++ b/server/src/middleware/authMiddleware.ts
@@ -20,7 +20,6 @@ const isPublicEndpoint = (url: string, method: string): boolean => {
   const conditionalEndpoints = [
     { url: "v1/packages", method: "GET" },
     { url: "v1/games", method: "GET" },
-    { url: "v1/file", method: "POST" },
   ];
 
   return (

--- a/server/src/schemes/package/packageSchemes.ts
+++ b/server/src/schemes/package/packageSchemes.ts
@@ -35,7 +35,7 @@ const themes = Joi.array()
   .items(
     Joi.object({
       name: Joi.string().required(),
-      comment: Joi.string(),
+      comment: Joi.string().allow(null, ""),
       questions,
     }).required()
   )

--- a/server/src/services/game/GameService.ts
+++ b/server/src/services/game/GameService.ts
@@ -25,6 +25,10 @@ export class GameService {
     return this.gameRepository.getAllGames(ctx, paginationOpts);
   }
 
+  public async delete(gameId: string) {
+    return this.gameRepository.deleteGame(gameId);
+  }
+
   public async create(
     ctx: ApiContext,
     gameData: IGameCreateData,

--- a/server/src/types/file/IStorage.ts
+++ b/server/src/types/file/IStorage.ts
@@ -9,6 +9,7 @@ import { OQContentStructure } from "types/file/structures/OQContentStructure";
 import { IPackageUploadResponse } from "types/package/IPackageUploadResponse";
 import { EFileSource } from "enums/file/EFileSource";
 import { Session } from "types/auth/session";
+import { IFile } from "types/file/IFile";
 
 export interface IStorage {
   /** @returns presigned url */
@@ -30,6 +31,13 @@ export interface IStorage {
     user?: User,
     pack?: Package
   ): Promise<string>;
+  /**
+   * @returns Record with `key:value` -> `filename:s3-file-upload-link`
+   */
+  performBulkFilesUpload(
+    filesData: { files: IFile[]; user?: User; pack?: Package },
+    expiresIn?: number
+  ): Promise<Record<string, string>>;
   delete(filename: string, session: Session): Promise<void>;
   // TODO: Create separate service for packages
   getPackage(id: number): Promise<IPackageListItem>;

--- a/server/src/types/game/IGame.ts
+++ b/server/src/types/game/IGame.ts
@@ -5,7 +5,9 @@ type pickFields =
   | "title"
   | "createdAt"
   | "currentRound"
+  | "isPrivate"
   | "players"
+  | "ageRestriction"
   | "maxPlayers"
   | "startedAt";
 

--- a/server/src/types/game/IGameListItem.ts
+++ b/server/src/types/game/IGameListItem.ts
@@ -1,5 +1,6 @@
 import { IShortUserInfo } from "types/user/IShortUserInfo";
 import { IPackageListItem } from "types/game/items/IPackageIListItem";
+import { EAgeRestriction } from "enums/game/EAgeRestriction";
 
 export interface IGameListItem {
   id: string;
@@ -7,6 +8,8 @@ export interface IGameListItem {
   title: string;
   createdAt: Date;
   currentRound: number;
+  isPrivate: boolean;
+  ageRestriction: EAgeRestriction;
   players: number;
   maxPlayers: number;
   startedAt: Date | null;

--- a/server/src/types/game/IGameRedisHash.ts
+++ b/server/src/types/game/IGameRedisHash.ts
@@ -1,0 +1,13 @@
+export interface IGameRedisHash {
+  id: string;
+  createdBy: string;
+  title: string;
+  createdAt: string; // Stored as timestamp string
+  isPrivate: string; // '0' | '1'
+  ageRestriction: string;
+  currentRound: string;
+  players: string;
+  maxPlayers: string;
+  startedAt: string; // Empty string if null
+  package: string;
+}

--- a/server/src/utils/StorageUtils.ts
+++ b/server/src/utils/StorageUtils.ts
@@ -22,4 +22,9 @@ export class StorageUtils {
     }
     return `${filename[0]}/${filename.substring(0, 2)}/${filename}`;
   }
+
+  public static getFilePath(filename: string) {
+    const fileWithPath = this.parseFilePath(filename);
+    return fileWithPath.replace(filename, "");
+  }
 }


### PR DESCRIPTION
Now games in redis stored inside hash set. Also created 3 indexes for games sorting -> by `createdAt`, by `isPrivate`, by `title`. Default sort value is `createdAt` (DESC)

Now packages uses bulk upload for files and file usages, which improves package upload speed by ~10x and reduces database hits (now only 3 instead of hit on every file + file usage record)